### PR TITLE
#8商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,10 @@
 class ItemsController < ApplicationController
-  before_action :set_item ,only: [:show,:edit,:update]
-  before_action :authenticate_user! ,except: [:index, :show]
-  before_action :move_to_index ,only: :edit
-
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :move_to_index, only: [:edit, :destroy]
 
   def index
-    @items = Item.includes(:user).order(created_at: "DESC")
+    @items = Item.includes(:user).order(created_at: 'DESC')
   end
 
   def new
@@ -31,7 +30,15 @@ class ItemsController < ApplicationController
     if @item.update(item_parameter)
       redirect_to item_path(@item.id)
     else
-      render "edit"
+      render 'edit'
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render 'show'
     end
   end
 
@@ -43,13 +50,10 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    if current_user.id != @item.user.id
-      redirect_to root_path
-    end
+    redirect_to root_path if current_user.id != @item.user.id
   end
 
   def set_item
     @item = Item.find(params[:id])
   end
-
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
     <% elsif user_signed_in? && current_user.id != @item.user.id %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'items#index'
   devise_for :users
-  resources :items ,only: [ :index, :new ,:create ,:show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# WHAT
商品削除機能の実装

# WHY
登録されている商品を削除できるようにするため。

### プルリクエストへ記載するgyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
URL：https://gyazo.com/0f7aec1d67d4dd3a41cfed8b91cf9db6
